### PR TITLE
Fixed SayFilter not returning all text.

### DIFF
--- a/addons/source-python/plugins/es_emulator/logic.py
+++ b/addons/source-python/plugins/es_emulator/logic.py
@@ -342,7 +342,7 @@ def on_say(command, index, team_only):
 
     # TODO: es.regsaycmd() should be handled here and not with SP's
     #       get_say_command()
-    if es.addons.sayFilter(userid, command.arg_string, team_only):
+    if es.addons.sayFilter(userid, command.command_string, team_only):
         return CommandReturn.CONTINUE
 
     return CommandReturn.BLOCK
@@ -358,7 +358,7 @@ def fire_es_player_chat(command, userid, team_only):
     event.set_int('userid', userid)
     event.set_bool('teamonly', team_only)
 
-    full_text = command.arg_string
+    full_text = command.command_string
     if (userid > 0 and full_text[0] == '"'
             and full_text[-1] == '"'
             and full_text.count('"') <= 2):


### PR DESCRIPTION
command.arg_string does not return all text, so fix it to command.command_string.
```python
from commands import CommandReturn
from commands.say import SayFilter

@SayFilter
def on_say(command, index, team_only):
    #say this is my text
    print(command.command_string)#this is my text
    print(command.arg_string)#is my text
    return CommandReturn.CONTINUE
```