### PR TITLE
Fixed an ArgumentError caused by sending an int instead of a DialogType 

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/es_C.py
+++ b/addons/source-python/plugins/es_emulator/eventscripts/es_C.py
@@ -1782,7 +1782,9 @@ def keygroupmsg(argv):
         dbgmsg(0, 'Error: \'message\' subkey was not found inside keygroup {}'.format(key_group_name))
         return
 
-    create_message(edict, atoi(argv[2]), key_msg)
+    type = DialogType(atoi(argv[2]))
+
+    create_message(edict, type, key_msg)
 
 @command
 def keygrouprename(argv):
@@ -2505,6 +2507,8 @@ def sendkeypmsg(userid, type, key_ptr):
 
     if not key_ptr:
         dbgmsg(0, 'Error: Invalid key for sending VGUI message.')
+
+    type = DialogType(type)
 
     create_message(edict, type, _make_keyvalues(key_ptr))
 


### PR DESCRIPTION
Code example:
```
event player_spawn
{
    popup create test_popup
    popup addline test_popup "Select a category"
    popup addline test_popup "->1. Primary weapons"
    popup addline test_popup "->2. Secondary weapons"
    popup addline test_popup "->3. Miscellaneous"
    popup addline test_popup "->0. Close/Exit"
    es popup send test_popup event_var(userid)
    es_msg Test Popup Script Ended
}
```

Outputs:
```
[SP] Caught an Exception:
Traceback (most recent call last):
  File "../addons/source-python/plugins/es_emulator/logic.py", line 103, in __call__
    es.addons.callBlock(self.block_name)
  File "../addons/source-python/plugins/es_emulator/eventscripts/es.py", line 356, in callBlock
    self.Blocks[blockname]()
  File "../addons/source-python/plugins/es_emulator/eventscripts/popup/popup.py", line 169, in consolecmd
    p.send(playerlib.getUseridList(users),prio)
  File "../addons/source-python/plugins/es_emulator/eventscripts/_libs/python/popuplib.py", line 256, in send
    user.handleQueue()
  File "../addons/source-python/plugins/es_emulator/eventscripts/_libs/python/popuplib.py", line 1444, in handleQueue
    menudisplay.send(self.userid)
  File "../addons/source-python/plugins/es_emulator/eventscripts/_libs/python/msglib.py", line 34, in send
    sendVguiDialog(userid, self.mode, self.kv)
  File "../addons/source-python/plugins/es_emulator/eventscripts/_libs/python/msglib.py", line 21, in sendVguiDialog
    es.sendkeypmsg(int(userid), int(msgtype), key._id_)
  File "../addons/source-python/plugins/es_emulator/eventscripts/es_C.py", line 2509, in sendkeypmsg
    create_message(edict, type, _make_keyvalues(key_ptr))

Boost.Python.ArgumentError: Python argument types in
    _messages.create_message(Edict, int, KeyValues)
did not match C++ signature:
    create_message(edict_t* edict, DIALOG_TYPE message_type, KeyValues* data)
```