### PR TITLE
Fix: Command GetLivingPlayerCount

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/es_C.py
+++ b/addons/source-python/plugins/es_emulator/eventscripts/es_C.py
@@ -1355,7 +1355,7 @@ def getlivingplayercount(argv):
         _set_last_error('Not enough arguments.')
         return
 
-    if len(argv) == 0:
+    if len(argv) == 1:
         team = None
     else:
         team = atoi(argv[1])


### PR DESCRIPTION
Fixed an issue that results in the variable returning the value 0, whenever the es_getlivingplayercount command is used without adding the team argument. 
Thanks to Xiazee for his help fixing this issue.