### PR TITLE
Fix uncaught ValueError in event KeyValues #55

### DIFF
--- a/addons/source-python/plugins/es_emulator/logic.py
+++ b/addons/source-python/plugins/es_emulator/logic.py
@@ -220,10 +220,14 @@ class ESEventListener(GameEventListener):
 es_event_listener = ESEventListener()
 
 def register_for_event_file(file_name):
-    events = KeyValues.load_from_file(file_name)
-    if events is None:
-        _set_last_error('Couldn\'t load events file.')
+    try:
+        events = KeyValues.load_from_file(file_name)
+        assert events is not None, "Should raise ValueError instead of returning None since February 2021."
+
+    except ValueError as ex:
+        _set_last_error(f'Couldn\'t load events file \'{file_name}\': {str(ex)}')
         return False
+        
 
     import es
 


### PR DESCRIPTION
The latest update to Source.Python Source-Python-Dev-Team/Source.Python@3d1789de24c482dafb10dfb80da4db82efdb5b1d made `KeyValues.load_from_file()` raise an exception if the file is not found instead of returning `NULL`/`None`

Fixes #55 